### PR TITLE
impr: CPO-539 Upgrade to Node 18.x and npm v9

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,7 @@
 	],
 	"plugins": ["prettier", "jest", "security"],
 	"parserOptions": {
-		"ecmaVersion": 2021
+		"ecmaVersion": 2023
 	},
 	"rules": {
 		"curly": "error",

--- a/.github/workflows/npm-merge-workflow.yml
+++ b/.github/workflows/npm-merge-workflow.yml
@@ -18,12 +18,11 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # refers to actions/setup-node@v3.5.1
         with:
-          node-version: 16
-      - run: npm i npm@8 -g
+          node-version: 18
+      - run: npm i npm@9 -g
       - run: npm config set registry https://$ARTIFACTORY_URL
       - run: npm config set replace-registry-host npm.pkg.github.com
       - run: npm config set //$ARTIFACTORY_URL:_auth "$(echo -n $ARTIFACTORY_TOKEN_EMAIL:$ARTIFACTORY_TOKEN | base64 -w 0)"
       - run: npm config set //$ARTIFACTORY_URL:email "$ARTIFACTORY_TOKEN_EMAIL"
-      - run: npm config set //$ARTIFACTORY_URL:always-auth true
       - run: npm install
       - run: npm run check

--- a/.github/workflows/validate-commit-message.yml
+++ b/.github/workflows/validate-commit-message.yml
@@ -21,13 +21,12 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # refers to actions/setup-node@v3.5.1
         with:
-          node-version: 16
-      - run: npm i npm@8 -g
+          node-version: 18
+      - run: npm i npm@9 -g
       - run: npm config set registry https://$ARTIFACTORY_URL
       - run: npm config set replace-registry-host npm.pkg.github.com
       - run: npm config set //$ARTIFACTORY_URL:_auth "$(echo -n $ARTIFACTORY_TOKEN_EMAIL:$ARTIFACTORY_TOKEN | base64 -w 0)"
       - run: npm config set //$ARTIFACTORY_URL:email "$ARTIFACTORY_TOKEN_EMAIL"
-      - run: npm config set //$ARTIFACTORY_URL:always-auth true
       - run: npm install --ignore-scripts
       - uses: wagoid/commitlint-github-action@baffd3c16c570c0a26bf89be729b81bb796e9bd5 # v3.1.4 commit hash, refers to wagoid/commitlint-github-action@3.1.4
         with:

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -18,13 +18,12 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # refers to actions/setup-node@v3.5.1
         with:
-          node-version: 16
-      - run: npm i npm@8 -g
+          node-version: 18
+      - run: npm i npm@9 -g
       - run: npm config set registry https://$ARTIFACTORY_URL
       - run: npm config set replace-registry-host npm.pkg.github.com
       - run: npm config set //$ARTIFACTORY_URL:_auth "$(echo -n $ARTIFACTORY_TOKEN_EMAIL:$ARTIFACTORY_TOKEN | base64 -w 0)"
       - run: npm config set //$ARTIFACTORY_URL:email "$ARTIFACTORY_TOKEN_EMAIL"
-      - run: npm config set //$ARTIFACTORY_URL:always-auth true
       - run: npm install --ignore-scripts
       - uses: JulienKode/pull-request-name-linter-action@2d32d4e7eb34ae4ff9c3c3ba0f5eaadb27bb0f2d # v0.2.0 commit hash, refers to JulienKode/pull-request-name-linter-action@0.2.0
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,24 +14,24 @@
         "winston": "^3.11.0"
       },
       "devDependencies": {
-        "@conformity/commitlint-config-conformity": "^1.2.4",
+        "@conformity/commitlint-config-conformity": "^1.2.5",
         "@types/jest": "^29.5.11",
         "@zeit/ncc": "^0.22.0",
         "commitlint-cli": "^1.1.3",
         "eslint": "^8.56.0",
-        "eslint-config-prettier": "^8.8.0",
+        "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-jest": "^27.6.3",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-security": "^1.7.1",
         "husky": "^8.0.3",
         "jest": "^29.7.0",
         "lint-staged": "^13.2.2",
-        "prettier": "^2.8.8"
+        "prettier": "^3.0.3"
       },
       "engines": {
-        "node": "^16",
-        "npm": "^8"
+        "node": "^18",
+        "npm": "^9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -771,9 +771,9 @@
       }
     },
     "node_modules/@conformity/commitlint-config-conformity": {
-      "version": "1.2.4",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@conformity/commitlint-config-conformity/-/@conformity/commitlint-config-conformity-1.2.4.tgz",
-      "integrity": "sha512-0iRcAB6PUCSBFkcdOfFAHu9kk6Bcfa2fIPdR/P1++5LzBE/zeBLkosZzZt7+qGwPlnZIOLU9/6YWeKQwd8+43A==",
+      "version": "1.2.5",
+      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@conformity/commitlint-config-conformity/-/@conformity/commitlint-config-conformity-1.2.5.tgz",
+      "integrity": "sha512-IMYloQ2krc1VFNV9li/AX/nQb7j25UliDZQO5hiDkCY3tj3E2vjZSET2z9sfjyXwdLo24XW2lT97xg6HE7N5Ig==",
       "dev": true,
       "dependencies": {
         "@babel/preset-typescript": "^7.14.5",
@@ -2596,6 +2596,15 @@
       "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
       "dependencies": {
         "@octokit/openapi-types": "^12.11.0"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5143,9 +5152,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.10.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
-      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
+      "version": "9.0.0",
+      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -5307,21 +5316,26 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "4.2.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
-      "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
+      "version": "5.0.1",
+      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/eslint-plugin-prettier/-/eslint-plugin-prettier-5.0.1.tgz",
+      "integrity": "sha512-m3u5RnR56asrwV/lDC4GHorlW75DsFfmUcjfCYylTUs85dBRnB7VM6xG8eCMJdeDRnppzmxZVf1GEPJvl1JmNg==",
       "dev": true,
       "dependencies": {
-        "prettier-linter-helpers": "^1.0.0"
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.8.5"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "peerDependencies": {
-        "eslint": ">=7.28.0",
-        "prettier": ">=2.0.0"
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "prettier": ">=3.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
         "eslint-config-prettier": {
           "optional": true
         }
@@ -10033,15 +10047,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.0.3",
+      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       }
     },
     "node_modules/prettier-linter-helpers": {
@@ -10868,6 +10882,19 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.8.8",
+      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/synckit/-/synckit-0.8.8.tgz",
+      "integrity": "sha512-HwOKAP7Wc5aRGYdKH+dw0PRRpbO841v2DENBtjnR5HFWoiNByAl7vrx3p0G/rCyYXQsrxqtX48TImFtPcIHSpQ==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
       }
     },
     "node_modules/temp-dir": {

--- a/package.json
+++ b/package.json
@@ -17,24 +17,24 @@
   "author": "Sam M. R.",
   "license": "MIT",
   "devDependencies": {
-    "@conformity/commitlint-config-conformity": "^1.2.4",
+    "@conformity/commitlint-config-conformity": "^1.2.5",
     "@types/jest": "^29.5.11",
     "@zeit/ncc": "^0.22.0",
     "commitlint-cli": "^1.1.3",
     "eslint": "^8.56.0",
-    "eslint-config-prettier": "^8.8.0",
+    "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-jest": "^27.6.3",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-security": "^1.7.1",
     "husky": "^8.0.3",
     "jest": "^29.7.0",
     "lint-staged": "^13.2.2",
-    "prettier": "^2.8.8"
+    "prettier": "^3.0.3"
   },
   "engines": {
-    "node": "^16",
-    "npm": "^8"
+    "node": "^18",
+    "npm": "^9"
   },
   "lint-staged": {
     "**/*.js": [


### PR DESCRIPTION
### Issue Link:

PD-16720

### What does it do?

Update this repo to Node 18.x by doing the following:

+ Ensure that `package.json:engines.node` = `^18`
+ Ensure that `package.json:engines.npm` = `^9`
+ Ensure that all GitHub Actions have `node-version: 18` and `npm: 9` set.
+ Ensure that `.eslintrc.json:parserOptions.ecmaVersion` = `2023`.

#### Checklist

- [x] BREAKING CHANGE - I have/intend to update all places where this package is used.
- [x] I will squash: PR title conforms to standard commit message format (`feat: XX-1234 ...`)
- [ ] I will merge without squashing: All commits conforms to standard commit message format (`feat: XX-1234 ...`)
- [ ] README update

---

#### Notes to reviewers

This PR was created with the `mass_repo_update` script.
